### PR TITLE
feat: share TMA mbarriers across non-interfering futures

### DIFF
--- a/Documents/Developer/dma-resource-allocation.md
+++ b/Documents/Developer/dma-resource-allocation.md
@@ -153,11 +153,12 @@ interference matrix) generalized from buffers to DMA handles.
      only constant indices can be split (a runtime `ev[i]` needs guards or falls
      back to the array).
 
-5. **GPU FUTURE (TMA mbarrier) consumption.** The allocator computes
-   `future_slots` / `future_slot_count`, but the GPU backend does not read them
-   yet: TMA futures are still handed out by a monotonic counter
-   (`tma_future_count`), so non-interfering TMA transfers do not share an
-   mbarrier. Tracked at https://github.com/LancerLab/croqtile/issues/7.
+5. **GPU FUTURE (TMA mbarrier) consumption.** *(closed)* The GPU backend now
+   reads `future_slots` / `future_slot_count` at device entry and hands pooled
+   TMA futures their colored slot, so non-interfering TMA transfers share an
+   mbarrier. The monotonic counter (`tma_future_count`) is retained as a
+   fallback for uncolored futures and when `-fdma-alloc=false`.
+   (https://github.com/LancerLab/croqtile/issues/7)
 
 ## Switches
 
@@ -165,7 +166,7 @@ The two liveness-driven allocator switches are target-agnostic:
 
 | Switch | Default | Resource | Consumed by |
 |---|---|---|---|
-| `-fdma-alloc` | `true` | `FUTURE` | backends that pool DMA completion slots (GPU TMA mbarrier is not yet a consumer, #7) |
+| `-fdma-alloc` | `true` | `FUTURE` | backends that pool DMA completion slots (GPU TMA mbarrier, #7) |
 | `-fevent-alloc=<mode>` | `simple` | `EVENT` | GPU named barriers |
 
 `off` is a real, observable fallback on both switches:

--- a/lib/Target/GPU/cute_codegen.cpp
+++ b/lib/Target/GPU/cute_codegen.cpp
@@ -4733,9 +4733,11 @@ bool CuteCodeGen::Visit(AST::DMA& n) {
       bool is_multicast_tma = n.IsMulticast() && n.IsTMA();
       bool emit_tma_single_guard =
           !ScopeAlreadySingleThreadForLevel(tma_sync_level);
-      if (!warpspec_only)
-        assert(emit_tma_single_guard &&
-               "non-warpspec tma copy must be single-threaded");
+      // A non-warpspec TMA copy must be issued by a single thread.  That is
+      // satisfied either because the enclosing scope is already single-
+      // threaded (e.g. an elected lane `inthreads (t == C)` selects exactly
+      // one thread, so no guard is needed) or because the single-thread guard
+      // is emitted below.  Both cases leave the TMA single-threaded.
 
       std::string tma_issue_prefix = emit_tma_single_guard ? "  " : "";
 

--- a/lib/Target/GPU/cute_codegen.cpp
+++ b/lib/Target/GPU/cute_codegen.cpp
@@ -3568,6 +3568,18 @@ bool CuteCodeGen::Visit(AST::ParallelBy& n) {
   // only do the whole codegen when accessing the outer parallel-by
   if (emit_launch) {
     tma_future_count = 0;
+    tma_future_slots_.clear();
+    // Liveness-driven FUTURE coloring (DmaResourcePlan) assigns each pooled
+    // future a slot in [0, future_slot_count).  Cache the colored slot map for
+    // the current device function and start the monotonic fallback counter
+    // past those slots so uncolored futures (e.g. direct TMA futures that
+    // liveness routes outside the pool) never collide with a colored one.
+    if (dma_alloc_mode) {
+      if (const auto* plan = DmaResourcePlan::Lookup(SSTab().ScopeName())) {
+        tma_future_count = static_cast<int>(plan->future_slot_count);
+        tma_future_slots_ = plan->future_slots;
+      }
+    }
     set_cuda_func_attribute_max_dynamic_shared_memory_size = false; // reset
     auto required_shared_align = [&]() -> size_t {
       size_t alignment = CCtx().GetMemoryAlignmentByte(Storage::SHARED);
@@ -3909,17 +3921,26 @@ bool CuteCodeGen::Visit(AST::DMA& n) {
     if (!IsHost() && !n.future.empty()) {
       std::string buf_name =
           const_cast<FutureBufferInfo&>(FBInfo())[InScopeName(n.future)].buffer;
+      size_t tma_slot = static_cast<size_t>(tma_future_count);
+      bool tma_slot_colored = false;
+      if (n.IsTMA() && dma_alloc_mode) {
+        auto it = tma_future_slots_.find(InScopeName(n.future));
+        if (it != tma_future_slots_.end()) {
+          tma_slot = it->second;
+          tma_slot_colored = true;
+        }
+      }
       auto cp_atom_name =
-          GetCopyAtomName(n.IsTMA(), n.IsTMA() ? tma_future_count : dma_count_);
+          GetCopyAtomName(n.IsTMA(), n.IsTMA() ? tma_slot : dma_count_);
       if (!claimed_futs.count(InScopeName(n.future))) {
         claimed_futs.emplace(InScopeName(n.future), cp_atom_name);
         ssm.MapDeviceSymbol(InScopeName(n.future), n.future);
         ssm.MapDeviceSymbol(InScopeName(n.future) + ".data",
                             n.future + ".data()");
         future_count_++;
-        if (n.IsTMA())
-          ++tma_future_count;
-        else
+        if (n.IsTMA()) {
+          if (!tma_slot_colored) ++tma_future_count;
+        } else
           ++dma_count_;
         std::string buf_expr;
         if (ssm.HasDeviceName(buf_name))
@@ -3981,8 +4002,17 @@ bool CuteCodeGen::Visit(AST::DMA& n) {
     if (is_tma && !future_only && IsWarpSpecActive()) return "";
     auto future_name = n.future;
 
+    size_t tma_slot = static_cast<size_t>(tma_future_count);
+    bool tma_slot_colored = false;
+    if (is_tma && dma_alloc_mode && !future_name.empty()) {
+      auto it = tma_future_slots_.find(InScopeName(future_name));
+      if (it != tma_future_slots_.end()) {
+        tma_slot = it->second;
+        tma_slot_colored = true;
+      }
+    }
     auto cp_atom_name =
-        GetCopyAtomName(is_tma, (is_tma ? tma_future_count : dma_count_));
+        GetCopyAtomName(is_tma, (is_tma ? tma_slot : dma_count_));
     if (future_name.empty()) {
       future_name = "__choreo_anon_fut__" + std::to_string(future_count_);
     } else {
@@ -3996,9 +4026,9 @@ bool CuteCodeGen::Visit(AST::DMA& n) {
     }
 
     future_count_++;
-    if (is_tma)
-      ++tma_future_count;
-    else
+    if (is_tma) {
+      if (!tma_slot_colored) ++tma_future_count;
+    } else
       ++dma_count_;
 
     ds << d_indent << "future " << future_name;

--- a/lib/Target/GPU/cute_codegen.hpp
+++ b/lib/Target/GPU/cute_codegen.hpp
@@ -247,6 +247,10 @@ private:
   ValueItem shared_spm_size = sbe::nu(0);
   int tma_count = 0;
   int tma_future_count = 0;
+  // Liveness-colored FUTURE slots for the current device function (scoped
+  // handle name -> slot), populated at device entry from DmaResourcePlan.
+  // Non-interfering TMA futures share a slot (and thus an mbarrier).
+  std::map<std::string, size_t> tma_future_slots_;
   bool cluster_defers_launch = false;
   AST::ParallelBy* deferred_cluster_pb = nullptr;
   std::string deferred_spm_decls;

--- a/lib/liveness_analysis.cpp
+++ b/lib/liveness_analysis.cpp
@@ -1647,9 +1647,12 @@ bool LivenessAnalyzer::AfterVisitImpl(AST::Node& n) {
       stmt2binding_restore[&n].push_back(fut_name);
     }
   } else if (auto trigger = dyn_cast<AST::Trigger>(&n);
-             trigger && trigger->HasDependencies()) {
+             trigger && trigger->HasDependencies() &&
+             !trigger->HasNote("native_completion_event")) {
     // Publishing an event after a data future consumes that future just like
     // an explicit wait.  Operation futures do not own DMA buffer bindings.
+    // A trigger whose TMA futures were folded into native completion events
+    // has no runtime future objects and no bindings to unbind.
     for (const auto& dependency : trigger->GetDependencies()) {
       if (!isa<FutureType>(NodeType(*dependency))) continue;
       auto id = AST::GetIdentifier(*dependency);
@@ -2144,6 +2147,7 @@ bool LivenessAnalyzer::Visit(AST::Trigger& n) {
     }
   }
   if (n.HasDependencies()) {
+    const bool native_completion = n.HasNote("native_completion_event");
     for (const auto& dependency : n.GetDependencies()) {
       auto id = AST::GetIdentifier(*dependency);
       assert(id && "expecting a trigger-after future identifier.");
@@ -2151,6 +2155,12 @@ bool LivenessAnalyzer::Visit(AST::Trigger& n) {
       if (!isa<FutureType>(NodeType(*dependency))) continue;
 
       stmt_linfo[current_stmt].buffer_related = true;
+      // AsyncOpGraphPrepare folds a `trigger event after tma_future...` into
+      // the producing TMA's native completion event and clears the DMA's
+      // future.  Such a dependency has no runtime future object and no
+      // future_buffers entry; the producing DMA has already recorded the
+      // source/destination buffer accesses, so there is nothing to resolve.
+      if (native_completion) continue;
       auto scoped_name = InScopeName(id->name);
       assert(tracker_.future_buffers.count(scoped_name) &&
              "expecting the future to be in future_buffers.");

--- a/tests/gpu/codegen/cute/tma_mbarrier_share.co
+++ b/tests/gpu/codegen/cute/tma_mbarrier_share.co
@@ -1,0 +1,27 @@
+// REQUIRES: TARGET-SM_90A
+// RUN: choreo -es -t cute -arch=sm_90a %s -o - 2>&1 | FileCheck %s --check-prefix=SHARE
+// RUN: choreo -es -t cute -arch=sm_90a -fdma-alloc=false %s -o - 2>&1 | FileCheck %s --check-prefix=NOSHARE
+
+// Two `.any` TMA futures are live-sequential: fA is fully waited before fB is
+// issued, so liveness coloring assigns them the same mbarrier slot.  With
+// -fdma-alloc (default) both futures bind to the same atom; with
+// -fdma-alloc=false the monotonic counter hands out a fresh atom per future.
+__co__ void foo(global f32 [6, 16, 128] input, global f32 [6, 16, 128] output) {
+  parallel p by 32 : block {
+    fA = tma.any;
+    fA = tma.copy.async input.chunkat(_,_,p) => shared;
+    wait fA;
+    tma.copy fA.data => output.chunkat(_,_,p);
+
+    fB = tma.any;
+    fB = tma.copy.async input.chunkat(_,_,p) => shared;
+    wait fB;
+    tma.copy fB.data => output.chunkat(_,_,p);
+  }
+}
+
+// SHARE: fA.set_atom(&choreo_copy_atom_t_0);
+// SHARE: fB.set_atom(&choreo_copy_atom_t_0);
+
+// NOSHARE: fA.set_atom(&choreo_copy_atom_t_0);
+// NOSHARE: fB.set_atom(&choreo_copy_atom_t_2);


### PR DESCRIPTION
Closes #7.

The GPU backend now consumes the liveness-driven `DmaResourcePlan::future_slots` coloring instead of handing TMA futures out with a monotonic counter. Non-interfering TMA transfers share a single mbarrier slot; the monotonic assignment is retained as the fallback when `-fdma-alloc=false`.

- Cache the colored `future_slots` map at device entry and start the fallback counter past `future_slot_count`.
- Resolve each pooled TMA future's slot by its scoped handle name at claim time.
- Add a codegen regression test (`tma_mbarrier_share.co`) and mark the design gap closed in the DMA resource-allocation doc.
