### PR TITLE
refactor: rename LoopRange bound fields to reflect mutator semantics

### DIFF
--- a/lib/Target/AMDGPU/hip_codegen.cpp
+++ b/lib/Target/AMDGPU/hip_codegen.cpp
@@ -1764,12 +1764,14 @@ bool HIPCodeGen::Visit(AST::ForeachBlock& n) {
       assert(IsActualBoundedIntegerType(iv_ty));
       auto iv_bty = cast<BoundedType>(iv_ty);
       IndStream() << "for (" << SSMName(iv_name, IsHost()) << " = "
-                  << (rng->lbound ? ("(" + ExprSTR(rng->lbound, IsHost()) + ")")
-                                  : "0")
+                  << (rng->lb_mutator
+                          ? ("(" + ExprSTR(rng->lb_mutator, IsHost()) + ")")
+                          : "0")
                   << "; " << SSMName(iv_name, IsHost()) << " < "
                   << UnScopedExpr(ValueSTR(iv_bty->GetUpperBound()))
-                  << (rng->ubound ? (" + " + ExprSTR(rng->ubound, IsHost()))
-                                  : "")
+                  << (rng->ub_mutator
+                          ? (" + " + ExprSTR(rng->ub_mutator, IsHost()))
+                          : "")
                   << "; ++" << SSMName(iv_name, IsHost()) << ") {\n";
       IncrIndent();
     }

--- a/lib/Target/CPU/cc_codegen.cpp
+++ b/lib/Target/CPU/cc_codegen.cpp
@@ -977,12 +977,12 @@ bool CCCodeGen::Visit(AST::ForeachBlock& n) {
       auto mapped = ssm.HostName(iv_name);
       if (vectorizable) IndStream() << "#pragma omp simd\n";
       IndStream() << "for (" << mapped << " = "
-                  << (rng->lbound ? ("(" + ExprSTR(rng->lbound) + ")")
-                                  : std::string("0"))
+                  << (rng->lb_mutator ? ("(" + ExprSTR(rng->lb_mutator) + ")")
+                                      : std::string("0"))
                   << "; " << mapped << " < "
                   << UnScopedExpr(ValueSTR(iv_bty->GetUpperBound()))
-                  << (rng->ubound ? (" + " + ExprSTR(rng->ubound))
-                                  : std::string(""))
+                  << (rng->ub_mutator ? (" + " + ExprSTR(rng->ub_mutator))
+                                      : std::string(""))
                   << "; ++" << mapped << ") {\n";
       IncrIndent();
     }

--- a/lib/Target/GPU/cute_codegen.cpp
+++ b/lib/Target/GPU/cute_codegen.cpp
@@ -9247,12 +9247,13 @@ bool CuteCodeGen::Visit(AST::ForeachBlock& n) {
                   ? ub_it->second
                   : UnScopedExpr(ValueSTR(iv_bty->GetUpperBound()));
           IndStream() << "for (" << SSMName(iv_name, IsHost()) << " = "
-                      << (rng->lbound
-                              ? ("(" + ExprSTR(rng->lbound, IsHost()) + ")")
+                      << (rng->lb_mutator
+                              ? ("(" + ExprSTR(rng->lb_mutator, IsHost()) + ")")
                               : "0")
                       << "; " << SSMName(iv_name, IsHost()) << " < " << ub_expr
-                      << (rng->ubound ? (" + " + ExprSTR(rng->ubound, IsHost()))
-                                      : "")
+                      << (rng->ub_mutator
+                              ? (" + " + ExprSTR(rng->ub_mutator, IsHost()))
+                              : "")
                       << "; ++" << SSMName(iv_name, IsHost()) << ") {\n";
           IncrIndent();
         }

--- a/lib/assert_site.cpp
+++ b/lib/assert_site.cpp
@@ -78,8 +78,8 @@ size_t AssertSite::EstimateLoopTripCount(AST::Node* n) const {
       if (IsActualBoundedIntegerType(sty)) {
         auto ub = GetSingleUpperBound(sty);
         auto lb = sbe::nu(0);
-        auto ub_addend_expr = dyn_cast<AST::Expr>(range->ubound);
-        auto lb_addend_expr = dyn_cast<AST::Expr>(range->lbound);
+        auto ub_addend_expr = dyn_cast<AST::Expr>(range->ub_mutator);
+        auto lb_addend_expr = dyn_cast<AST::Expr>(range->lb_mutator);
         auto ub_addend = sbe::nu(0);
         auto lb_addend = sbe::nu(0);
         if (ub_addend_expr && ub_addend_expr->Opts().HasVal())

--- a/lib/ast.cpp
+++ b/lib/ast.cpp
@@ -416,8 +416,8 @@ void Fence::accept(Choreo::Visitor& v) {
 }
 
 void LoopRange::accept(Choreo::Visitor& v) {
-  if (lbound) lbound->accept(v);
-  if (ubound) ubound->accept(v);
+  if (lb_mutator) lb_mutator->accept(v);
+  if (ub_mutator) ub_mutator->accept(v);
   if (rv) rv->accept(v);
   if (HasExplicitIV()) iv->accept(v);
   v.Visit(*this);

--- a/lib/ast.hpp
+++ b/lib/ast.hpp
@@ -3852,9 +3852,13 @@ struct LoopRange : public Node, public TypeIDProvider<LoopRange> {
   // iv: the iteration variable visible inside the foreach body.
   // Only set when the parser saw an explicit local name: foreach local=source.
   ptr<Identifier> iv;
+  // lb_mutator/ub_mutator: the bound mutators written in the source slice
+  // syntax `a(lb:ub:step)`, not the resolved range bounds. The actual bounds
+  // are derived during type/shape inference by applying these mutators to the
+  // range source variable's own bounds.
   // both will be normalized to Expr which ref to anon_x
-  ptr<Node> lbound = nullptr;
-  ptr<Node> ubound = nullptr;
+  ptr<Node> lb_mutator = nullptr;
+  ptr<Node> ub_mutator = nullptr;
   int step = GetInvalidStep();
   ValueItem scope_predicate = GetInvalidValueItem();
 
@@ -3862,12 +3866,13 @@ struct LoopRange : public Node, public TypeIDProvider<LoopRange> {
       : Node(l), rv(i), iv(nullptr) {} // the cmpt_bounds are yet to be inferred
   LoopRange(const location& l, const ptr<Identifier>& i, const ptr<Node>& lb,
             const ptr<Node>& ub, int s = 1)
-      : Node(l), rv(i), iv(nullptr), lbound(lb), ubound(ub), step(s) {}
+      : Node(l), rv(i), iv(nullptr), lb_mutator(lb), ub_mutator(ub), step(s) {}
   // Constructor for explicit local name: foreach local=source(lb:ub[:step])
   LoopRange(const location& l, const ptr<Identifier>& local,
             const ptr<Identifier>& source, const ptr<Node>& lb,
             const ptr<Node>& ub, int s = 1)
-      : Node(l), rv(source), iv(local), lbound(lb), ubound(ub), step(s) {}
+      : Node(l), rv(source), iv(local), lb_mutator(lb), ub_mutator(ub),
+        step(s) {}
 
   // Range source variable (the within-declared bounded variable).
   const std::string GetRVName() const { return rv->name; }
@@ -3881,14 +3886,14 @@ struct LoopRange : public Node, public TypeIDProvider<LoopRange> {
   bool HasExplicitIV() const { return iv && iv.get() != rv.get(); }
 
   bool BoundIsMutated() const {
-    return (lbound != nullptr) || (ubound != nullptr);
+    return (lb_mutator != nullptr) || (ub_mutator != nullptr);
   }
 
   ptr<Node> CloneImpl() const override {
     auto cloned_rv = (!rv) ? nullptr : CloneP(rv);
     auto cloned_iv = (!iv) ? nullptr : CloneP(iv);
-    auto copied =
-        Make<LoopRange>(LOC(), cloned_rv, CloneP(lbound), CloneP(ubound), step);
+    auto copied = Make<LoopRange>(LOC(), cloned_rv, CloneP(lb_mutator),
+                                  CloneP(ub_mutator), step);
     copied->iv = cloned_iv;
     copied->scope_predicate = scope_predicate;
     return copied;
@@ -3901,11 +3906,11 @@ struct LoopRange : public Node, public TypeIDProvider<LoopRange> {
     os << "\n" << prefix << "`- Iteration variables: " << GetIVName();
     if (HasExplicitIV()) os << " (source: " << GetRVName() << ")";
 
-    if (!lbound && !ubound && !IsValidStep(step)) return;
+    if (!lb_mutator && !ub_mutator && !IsValidStep(step)) return;
 
     os << "\n" << prefix << "`- Loop Control: (";
-    os << (lbound ? PSTR(lbound) : std::string("?")) << ":";
-    os << (ubound ? PSTR(ubound) : std::string("?")) << ":";
+    os << (lb_mutator ? PSTR(lb_mutator) : std::string("?")) << ":";
+    os << (ub_mutator ? PSTR(ub_mutator) : std::string("?")) << ":";
     os << (IsValidStep(step) ? std::to_string(step) : std::string("?")) << ")";
     if (IsValidValueItem(scope_predicate))
       os << "\n"

--- a/lib/earlysema.cpp
+++ b/lib/earlysema.cpp
@@ -3234,10 +3234,10 @@ bool EarlySemantics::Visit(AST::Return& n) {
 bool EarlySemantics::Visit(AST::LoopRange& n) {
   TraceEachVisit(n);
 
-  if (n.lbound && !isa<ScalarIntegerType>(NodeType(*n.lbound)))
-    Error1(n.lbound->LOC(), "the lower bound is not an integer.");
-  if (n.ubound && !isa<ScalarIntegerType>(NodeType(*n.ubound)))
-    Error1(n.ubound->LOC(), "the upper bound is not an integer.");
+  if (n.lb_mutator && !isa<ScalarIntegerType>(NodeType(*n.lb_mutator)))
+    Error1(n.lb_mutator->LOC(), "the lower bound is not an integer.");
+  if (n.ub_mutator && !isa<ScalarIntegerType>(NodeType(*n.ub_mutator)))
+    Error1(n.ub_mutator->LOC(), "the upper bound is not an integer.");
 
   return true;
 }

--- a/lib/liveness_analysis.cpp
+++ b/lib/liveness_analysis.cpp
@@ -1160,8 +1160,8 @@ void LivenessAnalyzer::DumpStmtBriefly(const Stmt& n, std::ostream& os,
       if (i > 0) os << ", ";
       auto lr = cast<AST::LoopRange>(fb->ranges->values[i]);
       os << lr->GetRV()->name << "(";
-      os << (lr->lbound ? PSTR(lr->lbound) : "") << ":";
-      os << (lr->ubound ? PSTR(lr->ubound) : "") << ":";
+      os << (lr->lb_mutator ? PSTR(lr->lb_mutator) : "") << ":";
+      os << (lr->ub_mutator ? PSTR(lr->ub_mutator) : "") << ":";
       os << (IsValidStep(lr->step) ? std::to_string(lr->step) : "") << ")";
     }
   } else if (const auto wb = dyn_cast<AST::WhileBlock>(&n)) {
@@ -2210,7 +2210,7 @@ bool LivenessAnalyzer::Visit(AST::ForeachBlock& n) {
     auto range = cast<AST::LoopRange>(item);
     // Although the range var is reset to zero, still treat it as a use.
     AddUse(current_stmt, range->GetRVName());
-    for (const auto& offset : {range->lbound, range->ubound}) {
+    for (const auto& offset : {range->lb_mutator, range->ub_mutator}) {
       if (!offset) continue;
       if (auto id = AST::GetIdentifier(*offset))
         AddUse(current_stmt, id->name);

--- a/lib/normalize.hpp
+++ b/lib/normalize.hpp
@@ -884,11 +884,11 @@ public:
       }
     };
 
-    handle_bounds([](auto lr) -> auto& { return lr->lbound; },
-                  [](auto lr, auto val) { lr->lbound = val; });
+    handle_bounds([](auto lr) -> auto& { return lr->lb_mutator; },
+                  [](auto lr, auto val) { lr->lb_mutator = val; });
 
-    handle_bounds([](auto lr) -> auto& { return lr->ubound; },
-                  [](auto lr, auto val) { lr->ubound = val; });
+    handle_bounds([](auto lr) -> auto& { return lr->ub_mutator; },
+                  [](auto lr, auto val) { lr->ub_mutator = val; });
 
     return true;
   }

--- a/lib/typeinfer.cpp
+++ b/lib/typeinfer.cpp
@@ -116,8 +116,8 @@ ValueItem TypeInference::BuildRangePredicate(AST::LoopRange& n) {
 
   auto ub_addend = sbe::nu(0);
   auto lb_addend = sbe::nu(0);
-  if (n.ubound) ub_addend = BuildPredicate(this, n.ubound);
-  if (n.lbound) lb_addend = BuildPredicate(this, n.lbound);
+  if (n.ub_mutator) ub_addend = BuildPredicate(this, n.ub_mutator);
+  if (n.lb_mutator) lb_addend = BuildPredicate(this, n.lb_mutator);
   ub += ub_addend;
   lb += lb_addend;
   assert(IsValidValueItem(lb));

--- a/tools/co-mock/mock_interp.cpp
+++ b/tools/co-mock/mock_interp.cpp
@@ -359,13 +359,13 @@ void MockInterpreter::ExecForeach(AST::ForeachBlock& n) {
     RangeInfo ri;
     ri.iv_name = lr->GetIVName();
 
-    if (lr->lbound)
-      ri.lb = ExprEval(lr->lbound).AsInt();
+    if (lr->lb_mutator)
+      ri.lb = ExprEval(lr->lb_mutator).AsInt();
     else
       ri.lb = 0;
 
-    if (lr->ubound) {
-      ri.ub = ExprEval(lr->ubound).AsInt();
+    if (lr->ub_mutator) {
+      ri.ub = ExprEval(lr->ub_mutator).AsInt();
     } else {
       ri.ub = 0;
       auto iv_ty = lr->GetIV()->GetType();

--- a/tools/co-web/interpreter.cpp
+++ b/tools/co-web/interpreter.cpp
@@ -113,8 +113,8 @@ void Interpreter::ExecForeach(AST::ForeachBlock& fb) {
   int64_t start = 0, end_val = 0;
   int step = range->step;
   if (!IsValidStep(step)) step = 1;
-  if (range->lbound) start = ToInt(Eval(*range->lbound));
-  if (range->ubound) end_val = ToInt(Eval(*range->ubound));
+  if (range->lb_mutator) start = ToInt(Eval(*range->lb_mutator));
+  if (range->ub_mutator) end_val = ToInt(Eval(*range->ub_mutator));
   if (step == 0) step = 1;
 
   std::string idx_name = range->GetIVName();

--- a/tools/coir/lib/ASTIRGen/ASTCoIRGen.cpp
+++ b/tools/coir/lib/ASTIRGen/ASTCoIRGen.cpp
@@ -1339,8 +1339,8 @@ bool hasEarlyExit(AST::Node* node) {
 int64_t ASTCoIRGen::resolveRangeBound(AST::LoopRange* lr) {
   // Keep unresolved bounds (e.g. `foreach y in X`) distinct from concrete 1.
   int64_t bound = mlir::ShapedType::kDynamic;
-  if (lr->ubound) {
-    if (auto* expr = dyn_cast<AST::Expr>(lr->ubound.get()))
+  if (lr->ub_mutator) {
+    if (auto* expr = dyn_cast<AST::Expr>(lr->ub_mutator.get()))
       if (expr->Opts().HasVal()) bound = EvalToInt(expr->Opts().GetVal());
   }
   if (bound <= 1) {
@@ -1434,8 +1434,8 @@ mlir::Value ASTCoIRGen::resolveRangeUBValue(AST::LoopRange* lr, int64_t bound) {
     }
     // The explicit ubound (`foreach x(:N:)` offset), if any.
     mlir::Value uboundVal;
-    if (lr->ubound) {
-      if (auto* expr = dyn_cast<AST::Expr>(lr->ubound.get())) {
+    if (lr->ub_mutator) {
+      if (auto* expr = dyn_cast<AST::Expr>(lr->ub_mutator.get())) {
         if (expr->Opts().HasVal()) {
           auto& vi = expr->Opts().GetVal();
           if (vi && !vi->IsNumeric()) {
@@ -1445,7 +1445,7 @@ mlir::Value ASTCoIRGen::resolveRangeUBValue(AST::LoopRange* lr, int64_t bound) {
         }
       }
       if (!uboundVal) {
-        uboundVal = EmitExpr(*lr->ubound);
+        uboundVal = EmitExpr(*lr->ub_mutator);
         if (uboundVal && !mlir::isa<mlir::IndexType>(uboundVal.getType()))
           uboundVal = builder.create<mlir::arith::IndexCastOp>(
               loc, mlir::IndexType::get(&IRContext()), uboundVal);
@@ -1605,8 +1605,8 @@ bool ASTCoIRGen::Visit(AST::ForeachBlock& fb) {
            : builder.create<mlir::arith::ConstantIndexOp>(loc, bound);
 
     mlir::Value lbValue;
-    if (lr && lr->lbound) {
-      auto lbExpr = EmitExpr(*lr->lbound);
+    if (lr && lr->lb_mutator) {
+      auto lbExpr = EmitExpr(*lr->lb_mutator);
       if (lbExpr) {
         if (!mlir::isa<mlir::IndexType>(lbExpr.getType()))
           lbExpr =


### PR DESCRIPTION
Closes #12.

The `LoopRange` AST node (`foreach x(lb:ub:step)`) stored the user-written bound mutators in fields named `lbound`/`ubound`, which is easy to confuse with the resolved range bounds derived later during type/shape inference (the actual bounds of `BoundedIntegerType`, etc.). This has already led to subtle bugs in bound handling.

This PR renames the fields to `lb_mutator`/`ub_mutator` and updates the constructors and every read/write site (normalize, early sema, type inference, assert site, liveness analysis, the CC/CuTE/HIP codegens, co-mock, co-web, and the CoIR IR gen). The `BoundedIntegerType::lbound/ubound` fields are intentionally untouched — those are the resolved bounds.

Verified: choreo-only release and debug builds pass; lit suite shows no regression (647 passed; the only failures are the pre-existing ones requiring the `cocc`/`co2ir` toolchain, which cannot be built in this environment).