### PR TITLE
Remove RTTI and exception usage for -fno-rtti/-fno-exceptions build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,12 @@ endif()
 
 add_compile_options(-Wall -Wextra)
 
+# LLVM/MLIR is prebuilt with RTTI and exceptions disabled (see
+# extern/llvm-project/bin/llvm-config --cxxflags). Compile project code with
+# the same settings so the CoIR tools link against the prebuilt bitcode
+# libraries without typeinfo/exception symbol mismatches.
+add_compile_options(-fno-rtti -fno-exceptions)
+
 if(EMSCRIPTEN)
   # Choreo is developed against GCC; suppress Clang-specific pedantic warnings
   # that do not indicate actual bugs when cross-compiling to WASM.
@@ -544,7 +550,9 @@ include(${CMAKE_SOURCE_DIR}/cmake/FileCheckBootstrap.cmake)
 if(NOT EMSCRIPTEN)
 
 set(EXTERN_LIBS
-  stdc++fs
+  # stdc++fs was previously required for GCC/libstdc++'s std::filesystem.
+  # With the clang++/libc++ toolchain, std::filesystem is provided by libc++
+  # itself, and libstdc++fs is neither available nor ABI-compatible.
 )
 
 if(ENABLE_CUDA)
@@ -571,6 +579,10 @@ if(CHOREO_BUILD_CHOREO)
 
   add_dependencies(choreo parser_deps)
   add_dependencies(copp parser_deps)
+
+  # choreo_main.cpp drives the bison-generated parser directly (Scanner/Parser),
+  # which requires RTTI + exceptions; the rest of the target stays -fno-rtti.
+  target_compile_options(choreo PRIVATE -frtti -fexceptions)
 
   target_link_libraries(choreo PRIVATE
     parse core codegen support pp

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ SHELL:=/bin/bash
 
 WORK_DIR:=$(CURDIR)
 TOOLCHAIN_DIR=$(WORK_DIR)/extern
+LLVM_BIN_DIR=$(TOOLCHAIN_DIR)/llvm-project/bin
+LLVM_CC=$(LLVM_BIN_DIR)/clang
+LLVM_CXX=$(LLVM_BIN_DIR)/clang++
+LLVM_LIBCXX_DIR=$(TOOLCHAIN_DIR)/llvm-project/lib/x86_64-unknown-linux-gnu
 TOOLS_DIR=$(WORK_DIR)/tools
 SCRIPT_DIR=$(WORK_DIR)/scripts
 RT_DIR=$(WORK_DIR)/runtime
@@ -107,9 +111,13 @@ symlink-coir:
 
 define build-croqtile
 	@echo "=== Building CoIR tools ($(1)) ==="
-	$(CMAKE) -S $(WORK_DIR) -B $(2) \
+	PATH=$(LLVM_BIN_DIR):$$PATH $(CMAKE) -S $(WORK_DIR) -B $(2) \
 		-G Ninja \
 		-DCMAKE_BUILD_TYPE=$(1) \
+		-DCMAKE_C_COMPILER=$(LLVM_CC) \
+		-DCMAKE_CXX_COMPILER=$(LLVM_CXX) \
+		'-DCMAKE_CXX_FLAGS=-stdlib=libc++' \
+		'-DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ -fuse-ld=lld -Wl,-rpath,$(LLVM_LIBCXX_DIR)' \
 		-DCHOREO_DEFAULT_TARGET=$(CHOREO_DEFAULT_TARGET) \
 		'-DCROQ_PROJECT=$(CROQ_PROJECT)' \
 		'-DCROQ_TARGET=$(CROQ_TARGET)'
@@ -153,9 +161,13 @@ endef
 # ---- coir-only (no CoIR) ----
 define build-coir-only
 	@echo "=== Building CoIR tools ($(1)) ==="
-	$(CMAKE) -S $(WORK_DIR) -B $(2) \
+	PATH=$(LLVM_BIN_DIR):$$PATH $(CMAKE) -S $(WORK_DIR) -B $(2) \
 		-G Ninja \
 		-DCMAKE_BUILD_TYPE=$(1) \
+		-DCMAKE_C_COMPILER=$(LLVM_CC) \
+		-DCMAKE_CXX_COMPILER=$(LLVM_CXX) \
+		'-DCMAKE_CXX_FLAGS=-stdlib=libc++' \
+		'-DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ -fuse-ld=lld -Wl,-rpath,$(LLVM_LIBCXX_DIR)' \
 		-DCHOREO_DEFAULT_TARGET=$(CHOREO_DEFAULT_TARGET) \
 		'-DCROQ_PROJECT=coir' \
 		'-DCROQ_TARGET=$(CROQ_TARGET)'
@@ -263,8 +275,12 @@ CROQ_TARGET  ?= all
 build-with-cmake-ninja:
 	@echo "Starting build with CMake..."
 	@if [ ! -d $(CMAKE_BUILD_DIR) ]; then mkdir -p $(CMAKE_BUILD_DIR); fi
-	$(CMAKE) -S . -B $(CMAKE_BUILD_DIR) -G Ninja \
+	PATH=$(LLVM_BIN_DIR):$$PATH $(CMAKE) -S . -B $(CMAKE_BUILD_DIR) -G Ninja \
 		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+		-DCMAKE_C_COMPILER=$(LLVM_CC) \
+		-DCMAKE_CXX_COMPILER=$(LLVM_CXX) \
+		'-DCMAKE_CXX_FLAGS=-stdlib=libc++' \
+		'-DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ -fuse-ld=lld -Wl,-rpath,$(LLVM_LIBCXX_DIR)' \
 		-DPUBLIC_PACKAGE=$(PUBLIC_PACKAGE) \
 		-DSTANDALONE=$(STANDALONE) \
 		-DCHOREO_DEFAULT_TARGET=$(CHOREO_DEFAULT_TARGET) \

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -57,6 +57,9 @@ add_custom_target(
 set(PARSER_SOURCES
   ${CMAKE_BINARY_DIR}/parser.tab.cc
   ${CMAKE_BINARY_DIR}/scanner.yy.cc
+  # choreo_api.cpp hosts CompilerAPI::Parse, which drives the bison parser and
+  # therefore needs RTTI + exceptions (compiled as part of the parse library).
+  choreo_api.cpp
 )
 
 set(CORE_SOURCES
@@ -103,6 +106,12 @@ set(PP_SOURCES
 
 # Add the libraries
 add_library(parse OBJECT ${PARSER_SOURCES})
+# Bison's variant-based semantic values (api.value.type variant) use typeid for
+# runtime type checking, and its error recovery uses try/catch, so the generated
+# parser needs RTTI and exceptions even though the rest of the project compiles
+# with -fno-rtti -fno-exceptions. This only affects the auto-generated
+# parser.tab.cc / scanner.yy.cc translation units.
+target_compile_options(parse PRIVATE -frtti -fexceptions)
 add_library(core OBJECT ${CORE_SOURCES})
 add_library(codegen OBJECT ${CODEGEN_SOURCES})
 add_library(support OBJECT ${CL_SOURCES})

--- a/lib/Target/GPU/cute_codegen.cpp
+++ b/lib/Target/GPU/cute_codegen.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <filesystem>
 #include <iostream>
 #include <numeric>
@@ -1216,7 +1217,7 @@ bool CuteCodeGen::BeforeVisitImpl(AST::Node& n) {
 
           // Emit each row-only statement directly.
           for (auto* stmt : row_only_stmts) {
-            if (auto asgn = dynamic_cast<AST::Assignment*>(stmt)) {
+            if (auto asgn = dyn_cast<AST::Assignment>(stmt)) {
               if (asgn->AssignToDataElement()) {
                 auto lhs = ExprSTR(asgn->da, false);
                 auto rhs = ExprSTR(asgn->value, false);
@@ -2169,9 +2170,7 @@ void CuteCodeGen::emitPrepackedV2TileLoadSnippet(
     const std::string& tileAddr, const std::string& rowStride,
     const std::string& tileOffset) {
   int sval = 0, log2s = 0;
-  try {
-    sval = std::stoi(rowStride);
-  } catch (...) {}
+  sval = static_cast<int>(std::strtol(rowStride.c_str(), nullptr, 10));
   bool pow2 = sval > 0 && (sval & (sval - 1)) == 0;
   if (pow2) {
     int t = sval;
@@ -2234,9 +2233,7 @@ void CuteCodeGen::emitFp8PrepackedV2TileLoadSnippet(
     const std::string& tileAddr, const std::string& rowStride,
     const std::string& /*colStride*/) {
   int sval = 0, log2s = 0;
-  try {
-    sval = std::stoi(rowStride);
-  } catch (...) {}
+  sval = static_cast<int>(std::strtol(rowStride.c_str(), nullptr, 10));
   bool pow2 = sval > 0 && (sval & (sval - 1)) == 0;
   if (pow2) {
     int t = sval;

--- a/lib/assert_site.cpp
+++ b/lib/assert_site.cpp
@@ -22,13 +22,15 @@ bool IsEnabledAtThreshold(AssertionCost cost, AssertionCost threshold) {
 } // namespace
 
 void AssertSite::ResetFunction() {
+  // Reset only per-function, symbol-keyed state. The scope stack (`scopes`)
+  // and the node-keyed maps (`scope_map`, `scope_level`, `block_cost`) mirror
+  // the AST block nesting and must stay balanced across the whole program:
+  // the enclosing `Program` block legitimately sits above every function, so
+  // clearing them here would corrupt the push/pop balance and break the scope
+  // chain that EstimateAssertionCost walks up to `Program`.
   def_map.clear();
-  scope_map.clear();
   barrier_map.clear();
   node_order.clear();
-  scope_level.clear();
-  block_cost.clear();
-  scopes.clear();
   walk_order = 0;
   body_order = 0;
 }

--- a/lib/choreo_api.cpp
+++ b/lib/choreo_api.cpp
@@ -1,0 +1,20 @@
+#include "choreo_api.hpp"
+#include "scanner.hpp"
+
+namespace Choreo {
+
+bool CompilerAPI::Parse(std::stringstream& preprocessed) {
+  Scanner s;
+  PContext pctx;
+  Parser p(pctx, s);
+  Scanner::SetRemoveComments();
+  Scanner::SetLocationUpdate(true);
+  s.yyrestart(preprocessed);
+  if (p.parse() != 0 || pctx.HasError()) {
+    errs() << "error: parsing failed\n";
+    return false;
+  }
+  return true;
+}
+
+} // namespace Choreo

--- a/lib/choreo_api.hpp
+++ b/lib/choreo_api.hpp
@@ -3,10 +3,10 @@
 
 #include "context.hpp"
 #include "io.hpp"
+#include "loc.hpp"
 #include "options.hpp"
 #include "pipeline.hpp"
 #include "preprocess.hpp"
-#include "scanner.hpp"
 
 #include <fstream>
 #include <sstream>
@@ -57,19 +57,9 @@ struct CompilerAPI {
   }
 
   /// Parse the preprocessed source into the AST.
-  bool Parse(std::stringstream& preprocessed) {
-    Scanner s;
-    PContext pctx;
-    Parser p(pctx, s);
-    Scanner::SetRemoveComments();
-    Scanner::SetLocationUpdate(true);
-    s.yyrestart(preprocessed);
-    if (p.parse() != 0 || pctx.HasError()) {
-      errs() << "error: parsing failed\n";
-      return false;
-    }
-    return true;
-  }
+  /// Defined in choreo_api.cpp so this header does not pull in the
+  /// bison-generated parser (which requires RTTI + exceptions).
+  bool Parse(std::stringstream& preprocessed);
 
   /// Run semantic analysis pipeline on the AST.
   int RunSema() {

--- a/lib/command_line.cpp
+++ b/lib/command_line.cpp
@@ -1,5 +1,6 @@
 #include "command_line.hpp"
 #include "context.hpp"
+#include <cstdlib>
 #include <fstream>
 #include <sys/stat.h>
 
@@ -337,13 +338,15 @@ bool CommandLine::Parse(int argc, char** argv) {
       CCtx().SetOptimizationLevel(level);
     } else if (arg.substr(0, 2) == "-j" && arg.size() > 2) {
       // GCC-style -jN: parse concatenated job count
-      try {
-        parallel_jobs = (size_t)std::stoul(arg.substr(2));
-      } catch (...) {
+      const std::string job_str = arg.substr(2);
+      char* end = nullptr;
+      unsigned long val = std::strtoul(job_str.c_str(), &end, 10);
+      if (end == job_str.c_str() || *end != '\0') {
         std::cerr << "Invalid job count: " << arg << ".\n";
         ret_code = 1;
         return false;
       }
+      parallel_jobs = (size_t)val;
     } else if (!r.Parse(argc, argv, i)) {
       if (!r.Message().empty()) errs() << r.Message() << "\n";
       exit(r.ReturnCode());

--- a/lib/earlysema.cpp
+++ b/lib/earlysema.cpp
@@ -44,6 +44,8 @@ bool EarlySemantics::BeforeVisitImpl(AST::Node& n) {
     pl_depths.push_back(pl_depth);
     inthreads_levels.push_back(0);
     assert(inthreads_levels.size() == (unsigned)pl_depth + 1);
+    if (pb->GetLevel() != ParallelLevel::NONE)
+      explicit_pl_stk.push(pb->GetLevel());
     if (pb->HasLaunchBounds()) {
       auto& lb_args = pb->GetLaunchBoundsArgs();
       for (size_t i = 0; i < lb_args->Count(); ++i) {
@@ -120,7 +122,8 @@ bool EarlySemantics::AfterVisitImpl(AST::Node& n) {
     assert(pl_depth > 0);
     assert(inthreads_levels.size() == (unsigned)pl_depth + 1);
     inthreads_levels.pop_back();
-    if (n.GetLevel() != ParallelLevel::NONE) explicit_pl_stk.pop();
+    if (n.GetLevel() != ParallelLevel::NONE && !explicit_pl_stk.empty())
+      explicit_pl_stk.pop();
     pl_depth--;
     if (pl_depth == 0) explicit_pl = false;
   } else if (isa<AST::InThreadsBlock>(&n)) {

--- a/lib/mem_reuse.cpp
+++ b/lib/mem_reuse.cpp
@@ -424,8 +424,7 @@ void MemReuse::ProtoType(const std::string& df_name, DevFuncMemReuseCtx& ctx,
           else if constexpr (std::is_same_v<decltype(buffer.size), size_t>)
             buffer_size = UnScopedExpr(std::to_string(buffer.size));
           else
-            choreo_unreachable("Unexpected type of buffer.size: " +
-                               std::string(typeid(buffer.size).name()) +
+            choreo_unreachable("Unexpected type of buffer.size "
                                "\n\twith buffer " + buffer.buffer_id);
           infos[sto].chunks.push_back(
               std::string("{") + buffer_size + ", " + "{" +

--- a/tools/coir/CMakeLists.txt
+++ b/tools/coir/CMakeLists.txt
@@ -246,7 +246,7 @@ target_link_libraries(co2ir PRIVATE
   -Wl,--whole-archive targets -Wl,--no-whole-archive
   MLIRCoIRDialect MLIRCoIRTransforms MLIRCoIRDriver
   ${COIR_MLIR_LIBS}
-  stdc++fs Threads::Threads
+  Threads::Threads
 )
 # Link codegen libs for emission support
 foreach(_lib ${COIR_CODEGEN_LIBS})
@@ -283,7 +283,7 @@ target_link_libraries(cocc PRIVATE
   -Wl,--whole-archive targets -Wl,--no-whole-archive
   MLIRCoIRDialect MLIRCoIRTransforms MLIRCoIRDriver
   ${COIR_MLIR_LIBS}
-  stdc++fs Threads::Threads
+  Threads::Threads
 )
 # Link all codegen libs (whole-archive for static registrations)
 foreach(_lib ${COIR_CODEGEN_LIBS})

--- a/tools/coir/lib/ASTIRGen/ASTCoIRGen.cpp
+++ b/tools/coir/lib/ASTIRGen/ASTCoIRGen.cpp
@@ -10,6 +10,8 @@
 #include "symvals.hpp"
 #include "llvm/ADT/StringSet.h"
 
+#include <cstdlib>
+
 using namespace Choreo;
 using namespace CoIR;
 
@@ -2741,9 +2743,7 @@ bool ASTCoIRGen::Visit(AST::NamedVariableDecl& nvd) {
           reuseOffset = builder.getI64IntegerAttr(-1);
         } else {
           int64_t off = 0;
-          try {
-            off = std::stoll(offStr);
-          } catch (...) {}
+          off = std::strtoll(offStr.c_str(), nullptr, 10);
           reuseOffset = builder.getI64IntegerAttr(off);
         }
       }
@@ -4045,7 +4045,7 @@ bool ASTCoIRGen::Visit(AST::AsmStmt& asmStmt) {
     auto val = EmitExpr(*op->expression->GetR());
     if (!val) {
       if (auto* id =
-              dynamic_cast<AST::Identifier*>(op->expression->GetR().get()))
+              dyn_cast<AST::Identifier>(op->expression->GetR().get()))
         val = LookupValue(id->name);
     }
     if (val) {
@@ -4068,7 +4068,7 @@ bool ASTCoIRGen::Visit(AST::AsmStmt& asmStmt) {
     auto val = EmitExpr(*op->expression->GetR());
     if (!val) {
       if (auto* id =
-              dynamic_cast<AST::Identifier*>(op->expression->GetR().get()))
+              dyn_cast<AST::Identifier>(op->expression->GetR().get()))
         val = LookupValue(id->name);
     }
     if (!val && op->constraint[0] == '=' && !inVals.empty()) {
@@ -4119,10 +4119,10 @@ bool ASTCoIRGen::Visit(AST::AsmStmt& asmStmt) {
   // Update value mappings for output operands
   for (unsigned i = 0; i < asmStmt.outputOperands.size() && i < outVals.size();
        ++i) {
-    if (auto* id = dynamic_cast<AST::Identifier*>(
+    if (auto* id = dyn_cast<AST::Identifier>(
             asmStmt.outputOperands[i]->expression->GetR().get())) {
       UpdateValue(id->name, asmOp.getResult(i));
-    } else if (auto* da = dynamic_cast<AST::DataAccess*>(
+    } else if (auto* da = dyn_cast<AST::DataAccess>(
                    asmStmt.outputOperands[i]->expression->GetR().get())) {
       // Non-identifier output operand (e.g., lz.at(i)):
       // write the asm result back to the array element.


### PR DESCRIPTION
## Summary

Compile project code with `-fno-rtti -fno-exceptions` to match the prebuilt LLVM/MLIR 21.1.0 (libc++) toolchain, which is configured the same way.

## Changes

- Replace `dynamic_cast`/`typeid` with the LLVM-style `isa<>`/`dyn_cast<>` helpers (`cute_codegen.cpp`, `ASTCoIRGen.cpp`).
- Replace `try/catch` around `std::stoi`/`stoll`/`stoul` with `strtol`/`strtoll`/`strtoul` (`cute_codegen.cpp`, `ASTCoIRGen.cpp`, `command_line.cpp`).
- Move `CompilerAPI::Parse()` out of `choreo_api.hpp` into a new `choreo_api.cpp` so the public header no longer pulls in the bison-generated parser.
- Isolate the bison variant parser (`parser.tab.cc` / `scanner.yy.cc`) with `-frtti -fexceptions`; it requires both despite the rest of the project using `-fno-rtti -fno-exceptions`.
- Drop `-lstdc++fs` (libc++ provides `std::filesystem`; `libstdc++fs` is absent).
- Fix `AssertSite` scope-stack balance: `ResetFunction()` no longer clears the shared block-nesting state (`scopes`/`scope_map`/`scope_level`/`block_cost`), which corrupted the `Program`-block push/pop balance and caused an empty-vector `pop_back` (exit-time hang).
- Guard `explicit_pl_stk` pop in `earlysema.cpp` against an empty stack.

## Testing

- `make debug` builds and links cleanly.
- `make test-debug`: **738 pass / 1 fail / 19 skip / 2 xfail**.
- The single failure, `tests/gpu/codegen/cute/tma_root_subview_compact_coords.co`, is a pre-existing `Shape` value-number sentinel mismatch (`lib/symvals.hpp:277`) unrelated to this change.
