### PR TITLE
fix(build): restore libc++ toolchain config for public repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,12 @@ endif()
 
 add_compile_options(-Wall -Wextra)
 
+# LLVM/MLIR is prebuilt with RTTI and exceptions disabled (see
+# extern/llvm-project/bin/llvm-config --cxxflags). Compile project code with
+# the same settings so the CoIR tools link against the prebuilt bitcode
+# libraries without typeinfo/exception symbol mismatches.
+add_compile_options(-fno-rtti -fno-exceptions)
+
 if(EMSCRIPTEN)
   # Choreo is developed against GCC; suppress Clang-specific pedantic warnings
   # that do not indicate actual bugs when cross-compiling to WASM.
@@ -544,7 +550,9 @@ include(${CMAKE_SOURCE_DIR}/cmake/FileCheckBootstrap.cmake)
 if(NOT EMSCRIPTEN)
 
 set(EXTERN_LIBS
-  stdc++fs
+  # stdc++fs was previously required for GCC/libstdc++'s std::filesystem.
+  # With the clang++/libc++ toolchain, std::filesystem is provided by libc++
+  # itself, and libstdc++fs is neither available nor ABI-compatible.
 )
 
 if(ENABLE_CUDA)
@@ -571,6 +579,10 @@ if(CHOREO_BUILD_CHOREO)
 
   add_dependencies(choreo parser_deps)
   add_dependencies(copp parser_deps)
+
+  # choreo_main.cpp drives the bison-generated parser directly (Scanner/Parser),
+  # which requires RTTI + exceptions; the rest of the target stays -fno-rtti.
+  target_compile_options(choreo PRIVATE -frtti -fexceptions)
 
   target_link_libraries(choreo PRIVATE
     parse core codegen support pp

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ SHELL:=/bin/bash
 
 WORK_DIR:=$(CURDIR)
 TOOLCHAIN_DIR=$(WORK_DIR)/extern
+LLVM_BIN_DIR=$(TOOLCHAIN_DIR)/llvm-project/bin
+LLVM_CC=$(LLVM_BIN_DIR)/clang
+LLVM_CXX=$(LLVM_BIN_DIR)/clang++
+LLVM_LIBCXX_DIR=$(TOOLCHAIN_DIR)/llvm-project/lib/x86_64-unknown-linux-gnu
 TOOLS_DIR=$(WORK_DIR)/tools
 SCRIPT_DIR=$(WORK_DIR)/scripts
 RT_DIR=$(WORK_DIR)/runtime
@@ -107,9 +111,13 @@ symlink-coir:
 
 define build-croqtile
 	@echo "=== Building CoIR tools ($(1)) ==="
-	$(CMAKE) -S $(WORK_DIR) -B $(2) \
+	PATH=$(LLVM_BIN_DIR):$$PATH $(CMAKE) -S $(WORK_DIR) -B $(2) \
 		-G Ninja \
 		-DCMAKE_BUILD_TYPE=$(1) \
+		-DCMAKE_C_COMPILER=$(LLVM_CC) \
+		-DCMAKE_CXX_COMPILER=$(LLVM_CXX) \
+		'-DCMAKE_CXX_FLAGS=-stdlib=libc++' \
+		'-DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ -fuse-ld=lld -Wl,-rpath,$(LLVM_LIBCXX_DIR)' \
 		-DCHOREO_DEFAULT_TARGET=$(CHOREO_DEFAULT_TARGET) \
 		'-DCROQ_PROJECT=$(CROQ_PROJECT)' \
 		'-DCROQ_TARGET=$(CROQ_TARGET)'
@@ -153,9 +161,13 @@ endef
 # ---- coir-only (no CoIR) ----
 define build-coir-only
 	@echo "=== Building CoIR tools ($(1)) ==="
-	$(CMAKE) -S $(WORK_DIR) -B $(2) \
+	PATH=$(LLVM_BIN_DIR):$$PATH $(CMAKE) -S $(WORK_DIR) -B $(2) \
 		-G Ninja \
 		-DCMAKE_BUILD_TYPE=$(1) \
+		-DCMAKE_C_COMPILER=$(LLVM_CC) \
+		-DCMAKE_CXX_COMPILER=$(LLVM_CXX) \
+		'-DCMAKE_CXX_FLAGS=-stdlib=libc++' \
+		'-DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ -fuse-ld=lld -Wl,-rpath,$(LLVM_LIBCXX_DIR)' \
 		-DCHOREO_DEFAULT_TARGET=$(CHOREO_DEFAULT_TARGET) \
 		'-DCROQ_PROJECT=coir' \
 		'-DCROQ_TARGET=$(CROQ_TARGET)'
@@ -263,8 +275,12 @@ CROQ_TARGET  ?= all
 build-with-cmake-ninja:
 	@echo "Starting build with CMake..."
 	@if [ ! -d $(CMAKE_BUILD_DIR) ]; then mkdir -p $(CMAKE_BUILD_DIR); fi
-	$(CMAKE) -S . -B $(CMAKE_BUILD_DIR) -G Ninja \
+	PATH=$(LLVM_BIN_DIR):$$PATH $(CMAKE) -S . -B $(CMAKE_BUILD_DIR) -G Ninja \
 		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+		-DCMAKE_C_COMPILER=$(LLVM_CC) \
+		-DCMAKE_CXX_COMPILER=$(LLVM_CXX) \
+		'-DCMAKE_CXX_FLAGS=-stdlib=libc++' \
+		'-DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ -fuse-ld=lld -Wl,-rpath,$(LLVM_LIBCXX_DIR)' \
 		-DPUBLIC_PACKAGE=$(PUBLIC_PACKAGE) \
 		-DSTANDALONE=$(STANDALONE) \
 		-DCHOREO_DEFAULT_TARGET=$(CHOREO_DEFAULT_TARGET) \

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -57,7 +57,8 @@ add_custom_target(
 set(PARSER_SOURCES
   ${CMAKE_BINARY_DIR}/parser.tab.cc
   ${CMAKE_BINARY_DIR}/scanner.yy.cc
-  # choreo_api.cpp hosts CompilerAPI::Parse, which drives the bison parser.
+  # choreo_api.cpp hosts CompilerAPI::Parse, which drives the bison parser and
+  # therefore needs RTTI + exceptions (compiled as part of the parse library).
   choreo_api.cpp
 )
 
@@ -105,6 +106,12 @@ set(PP_SOURCES
 
 # Add the libraries
 add_library(parse OBJECT ${PARSER_SOURCES})
+# Bison's variant-based semantic values (api.value.type variant) use typeid for
+# runtime type checking, and its error recovery uses try/catch, so the generated
+# parser needs RTTI and exceptions even though the rest of the project compiles
+# with -fno-rtti -fno-exceptions. This only affects the auto-generated
+# parser.tab.cc / scanner.yy.cc translation units.
+target_compile_options(parse PRIVATE -frtti -fexceptions)
 add_library(core OBJECT ${CORE_SOURCES})
 add_library(codegen OBJECT ${CODEGEN_SOURCES})
 add_library(support OBJECT ${CL_SOURCES})

--- a/tools/coir/CMakeLists.txt
+++ b/tools/coir/CMakeLists.txt
@@ -246,7 +246,7 @@ target_link_libraries(co2ir PRIVATE
   -Wl,--whole-archive targets -Wl,--no-whole-archive
   MLIRCoIRDialect MLIRCoIRTransforms MLIRCoIRDriver
   ${COIR_MLIR_LIBS}
-  stdc++fs Threads::Threads
+  Threads::Threads
 )
 # Link codegen libs for emission support
 foreach(_lib ${COIR_CODEGEN_LIBS})
@@ -283,7 +283,7 @@ target_link_libraries(cocc PRIVATE
   -Wl,--whole-archive targets -Wl,--no-whole-archive
   MLIRCoIRDialect MLIRCoIRTransforms MLIRCoIRDriver
   ${COIR_MLIR_LIBS}
-  stdc++fs Threads::Threads
+  Threads::Threads
 )
 # Link all codegen libs (whole-archive for static registrations)
 foreach(_lib ${COIR_CODEGEN_LIBS})


### PR DESCRIPTION
## Summary

`make test-debug` fails to link on `main` with:

```
ld.lld: error: unable to find library -lstdc++fs
```

**Root cause:** commit `66aa348` ("fix(build): restore internal gcc/libstdc++ toolchain config") was cherry-picked from the internal `choreo` repo, which builds against a gcc/libstdc++ LLVM toolchain. The public `croqtile` repo builds against the prebuilt libc++ LLVM in `extern/llvm-project` (`llvm-config --cxxflags` → `-stdlib=libc++`), so the gcc/libstdc++ config is incompatible:

- `-lstdc++fs` is a libstdc++/gcc-only flag; libc++ provides `std::filesystem` itself.
- The clang + `-stdlib=libc++` + `-fuse-ld=lld` toolchain flags were stripped from the `Makefile`.
- `-fno-rtti -fno-exceptions` (required to match the prebuilt LLVM/MLIR) and the bison parser's `-frtti -fexceptions` exception were removed.

This revert restores the libc++ toolchain config established in `3b24a13`.

## Verification

`make test-debug JOBS=16`:

- **738 passed / 1 pre-existing fail** (matches the baseline documented in `3b24a13`: "738 pass / 1 pre-existing fail").
- The single failure (`tests/gpu/codegen/cute/tma_root_subview_compact_coords.co`) is a pre-existing assertion crash in `lib/symvals.hpp` (value numbering), unrelated to this change.

## Note

No MARA code changes are included; the MARA fence-elision (`89b6635`) and DMA allocator (`70c3d6b`) commits are already ancestors of `main`.