### PR TITLE
build: restore clang++/libc++ toolchain config for public repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,12 @@ endif()
 
 add_compile_options(-Wall -Wextra)
 
+# LLVM/MLIR is prebuilt with RTTI and exceptions disabled (see
+# extern/llvm-project/bin/llvm-config --cxxflags). Compile project code with
+# the same settings so the CoIR tools link against the prebuilt bitcode
+# libraries without typeinfo/exception symbol mismatches.
+add_compile_options(-fno-rtti -fno-exceptions)
+
 if(EMSCRIPTEN)
   # Choreo is developed against GCC; suppress Clang-specific pedantic warnings
   # that do not indicate actual bugs when cross-compiling to WASM.
@@ -544,7 +550,9 @@ include(${CMAKE_SOURCE_DIR}/cmake/FileCheckBootstrap.cmake)
 if(NOT EMSCRIPTEN)
 
 set(EXTERN_LIBS
-  stdc++fs
+  # stdc++fs was previously required for GCC/libstdc++'s std::filesystem.
+  # With the clang++/libc++ toolchain, std::filesystem is provided by libc++
+  # itself, and libstdc++fs is neither available nor ABI-compatible.
 )
 
 if(ENABLE_CUDA)
@@ -571,6 +579,10 @@ if(CHOREO_BUILD_CHOREO)
 
   add_dependencies(choreo parser_deps)
   add_dependencies(copp parser_deps)
+
+  # choreo_main.cpp drives the bison-generated parser directly (Scanner/Parser),
+  # which requires RTTI + exceptions; the rest of the target stays -fno-rtti.
+  target_compile_options(choreo PRIVATE -frtti -fexceptions)
 
   target_link_libraries(choreo PRIVATE
     parse core codegen support pp

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ SHELL:=/bin/bash
 
 WORK_DIR:=$(CURDIR)
 TOOLCHAIN_DIR=$(WORK_DIR)/extern
+LLVM_BIN_DIR=$(TOOLCHAIN_DIR)/llvm-project/bin
+LLVM_CC=$(LLVM_BIN_DIR)/clang
+LLVM_CXX=$(LLVM_BIN_DIR)/clang++
+LLVM_LIBCXX_DIR=$(TOOLCHAIN_DIR)/llvm-project/lib/x86_64-unknown-linux-gnu
 TOOLS_DIR=$(WORK_DIR)/tools
 SCRIPT_DIR=$(WORK_DIR)/scripts
 RT_DIR=$(WORK_DIR)/runtime
@@ -107,9 +111,13 @@ symlink-coir:
 
 define build-croqtile
 	@echo "=== Building CoIR tools ($(1)) ==="
-	$(CMAKE) -S $(WORK_DIR) -B $(2) \
+	PATH=$(LLVM_BIN_DIR):$$PATH $(CMAKE) -S $(WORK_DIR) -B $(2) \
 		-G Ninja \
 		-DCMAKE_BUILD_TYPE=$(1) \
+		-DCMAKE_C_COMPILER=$(LLVM_CC) \
+		-DCMAKE_CXX_COMPILER=$(LLVM_CXX) \
+		'-DCMAKE_CXX_FLAGS=-stdlib=libc++' \
+		'-DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ -fuse-ld=lld -Wl,-rpath,$(LLVM_LIBCXX_DIR)' \
 		-DCHOREO_DEFAULT_TARGET=$(CHOREO_DEFAULT_TARGET) \
 		'-DCROQ_PROJECT=$(CROQ_PROJECT)' \
 		'-DCROQ_TARGET=$(CROQ_TARGET)'
@@ -153,9 +161,13 @@ endef
 # ---- coir-only (no CoIR) ----
 define build-coir-only
 	@echo "=== Building CoIR tools ($(1)) ==="
-	$(CMAKE) -S $(WORK_DIR) -B $(2) \
+	PATH=$(LLVM_BIN_DIR):$$PATH $(CMAKE) -S $(WORK_DIR) -B $(2) \
 		-G Ninja \
 		-DCMAKE_BUILD_TYPE=$(1) \
+		-DCMAKE_C_COMPILER=$(LLVM_CC) \
+		-DCMAKE_CXX_COMPILER=$(LLVM_CXX) \
+		'-DCMAKE_CXX_FLAGS=-stdlib=libc++' \
+		'-DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ -fuse-ld=lld -Wl,-rpath,$(LLVM_LIBCXX_DIR)' \
 		-DCHOREO_DEFAULT_TARGET=$(CHOREO_DEFAULT_TARGET) \
 		'-DCROQ_PROJECT=coir' \
 		'-DCROQ_TARGET=$(CROQ_TARGET)'
@@ -263,8 +275,12 @@ CROQ_TARGET  ?= all
 build-with-cmake-ninja:
 	@echo "Starting build with CMake..."
 	@if [ ! -d $(CMAKE_BUILD_DIR) ]; then mkdir -p $(CMAKE_BUILD_DIR); fi
-	$(CMAKE) -S . -B $(CMAKE_BUILD_DIR) -G Ninja \
+	PATH=$(LLVM_BIN_DIR):$$PATH $(CMAKE) -S . -B $(CMAKE_BUILD_DIR) -G Ninja \
 		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+		-DCMAKE_C_COMPILER=$(LLVM_CC) \
+		-DCMAKE_CXX_COMPILER=$(LLVM_CXX) \
+		'-DCMAKE_CXX_FLAGS=-stdlib=libc++' \
+		'-DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ -fuse-ld=lld -Wl,-rpath,$(LLVM_LIBCXX_DIR)' \
 		-DPUBLIC_PACKAGE=$(PUBLIC_PACKAGE) \
 		-DSTANDALONE=$(STANDALONE) \
 		-DCHOREO_DEFAULT_TARGET=$(CHOREO_DEFAULT_TARGET) \

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -57,7 +57,8 @@ add_custom_target(
 set(PARSER_SOURCES
   ${CMAKE_BINARY_DIR}/parser.tab.cc
   ${CMAKE_BINARY_DIR}/scanner.yy.cc
-  # choreo_api.cpp hosts CompilerAPI::Parse, which drives the bison parser.
+  # choreo_api.cpp hosts CompilerAPI::Parse, which drives the bison parser and
+  # therefore needs RTTI + exceptions (compiled as part of the parse library).
   choreo_api.cpp
 )
 
@@ -106,6 +107,12 @@ set(PP_SOURCES
 
 # Add the libraries
 add_library(parse OBJECT ${PARSER_SOURCES})
+# Bison's variant-based semantic values (api.value.type variant) use typeid for
+# runtime type checking, and its error recovery uses try/catch, so the generated
+# parser needs RTTI and exceptions even though the rest of the project compiles
+# with -fno-rtti -fno-exceptions. This only affects the auto-generated
+# parser.tab.cc / scanner.yy.cc translation units.
+target_compile_options(parse PRIVATE -frtti -fexceptions)
 add_library(core OBJECT ${CORE_SOURCES})
 add_library(codegen OBJECT ${CODEGEN_SOURCES})
 add_library(support OBJECT ${CL_SOURCES})

--- a/tools/coir/CMakeLists.txt
+++ b/tools/coir/CMakeLists.txt
@@ -246,7 +246,7 @@ target_link_libraries(co2ir PRIVATE
   -Wl,--whole-archive targets -Wl,--no-whole-archive
   MLIRCoIRDialect MLIRCoIRTransforms MLIRCoIRDriver
   ${COIR_MLIR_LIBS}
-  stdc++fs Threads::Threads
+  Threads::Threads
 )
 # Link codegen libs for emission support
 foreach(_lib ${COIR_CODEGEN_LIBS})
@@ -283,7 +283,7 @@ target_link_libraries(cocc PRIVATE
   -Wl,--whole-archive targets -Wl,--no-whole-archive
   MLIRCoIRDialect MLIRCoIRTransforms MLIRCoIRDriver
   ${COIR_MLIR_LIBS}
-  stdc++fs Threads::Threads
+  Threads::Threads
 )
 # Link all codegen libs (whole-archive for static registrations)
 foreach(_lib ${COIR_CODEGEN_LIBS})


### PR DESCRIPTION
## Summary

The public repo ships a libc++-built LLVM in `extern/llvm-project`, but commit `66aa348` cherry-picked the **internal** gcc/libstdc++ toolchain config into the public tree, which breaks the build (`unable to find library -lstdc++fs`).

## What this does

- Pins the build to the bundled clang++ with `-stdlib=libc++` (Makefile + CMake).
- Adds `-fno-rtti -fno-exceptions` to match the prebuilt LLVM (with `-frtti -fexceptions` on the bison-generated parser and `choreo` driver, which require them).
- Drops the `stdc++fs` link (libc++ provides `std::filesystem` natively; `libstdc++fs` is neither present nor ABI-compatible).

## Test plan

`make test-debug` builds and runs green with this applied. The MARA B1 fence PR (#18) depends on this to build.